### PR TITLE
Update miner.cpp

### DIFF
--- a/src/LLP/miner.cpp
+++ b/src/LLP/miner.cpp
@@ -199,11 +199,6 @@ namespace LLP
             /* On Generic Event, Broadcast new block if flagged. */
             case EVENTS::GENERIC:
             {
-                /* On generic events, return if no workers subscribed. */
-                uint32_t count = nSubscribed.load();
-                if(count == 0)
-                    return;
-
                 /* Check for a new round. */
                 {
                     LOCK(MUTEX);
@@ -213,6 +208,11 @@ namespace LLP
 
                 /* Alert workers of new round. */
                 respond(NEW_ROUND);
+                        
+                /* On generic events, return if no workers subscribed. */
+                uint32_t count = nSubscribed.load();
+                if(count == 0)
+                    return;
 
                 uint1024_t hashBlock;
                 std::vector<uint8_t> vData;

--- a/src/LLP/miner.cpp
+++ b/src/LLP/miner.cpp
@@ -202,7 +202,7 @@ namespace LLP
                 /* Check for a new round. */
                 {
                     LOCK(MUTEX);
-                    if(check_best_height())
+                    if(!check_best_height() && check_round())
                         return;
                 }
 


### PR DESCRIPTION
Updated EVENT::GENERIC in miner LLP to send a NEW_ROUND packet before checking if subscribed.

The miner won't have to poll for height if implemented this way and can improve latency of receiving block data.